### PR TITLE
Improved env imports

### DIFF
--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -1,0 +1,48 @@
+import dotenv from "dotenv";
+import fs from "fs"
+
+if (fs.existsSync(".env.test")) {
+  console.debug("Using .env.test file to supply config environment variables");
+  dotenv.config({ path: ".env.test" });
+} else if (fs.existsSync(".env.development")) {
+  console.debug("Using .env.development file to supply config environment variables");
+  dotenv.config({ path: ".env.development" });
+} else if (fs.existsSync(".env.production")) {
+  console.debug("Using .env.production file to supply config environment variables");
+  dotenv.config({ path: ".env.production" });
+} else {
+  console.debug("Using .env file to supply config environment variables");
+  dotenv.config({ path: ".env" });
+}
+
+export const ENVIRONMENT = process.env.NODE_ENV;
+export const DB_USER = process.env.DB_USER
+export const DB_PASS = process.env.DB_PASS
+export const DB_NAME = process.env.DB_NAME
+export const DB_HOST = process.env.DB_HOST
+export const DB_PORT = process.env.DB_PORT
+
+if (!DB_USER) {
+  console.log("Set DB_USER environment variable.");
+  process.exit(1);
+}
+
+if (!DB_PASS) {
+  console.log("Set DB_PASS environment variable.");
+  process.exit(1);
+}
+
+if (!DB_NAME) {
+  console.log("Set DB_NAME environment variable.");
+  process.exit(1);
+}
+
+if (!DB_HOST) {
+  console.log("Set DB_HOST environment variable.");
+  process.exit(1);
+}
+
+if (!DB_PORT) {
+  console.log("Set DB_PORT environment variable.");
+  process.exit(1);
+}

--- a/src/infrastructure/database/config/config.js
+++ b/src/infrastructure/database/config/config.js
@@ -1,26 +1,25 @@
-require ("dotenv").config();
+require("dotenv").config();
 
-module.exports = 
-{
-  "development": {
-    "username": process.env.DB_USER,
-    "password": process.env.DB_PASS,
-    "database": process.env.DB_NAME,
-    "host": process.env.DB_HOST,
-    "dialect": "mysql"
+module.exports = {
+  development: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    dialect: "mysql",
   },
-  "test": {
-    "username": "root",
-    "password": null,
-    "database": "database_test",
-    "host": "127.0.0.1",
-    "dialect": "mysql"
+  test: {
+    username: "root",
+    password: null,
+    database: "database_test",
+    host: "127.0.0.1",
+    dialect: "mysql",
   },
-  "production": {
-    "username": "root",
-    "password": null,
-    "database": "database_production",
-    "host": "127.0.0.1",
-    "dialect": "mysql"
-  }
-}
+  production: {
+    username: "root",
+    password: null,
+    database: "database_production",
+    host: "127.0.0.1",
+    dialect: "mysql",
+  },
+};

--- a/src/infrastructure/database/index.ts
+++ b/src/infrastructure/database/index.ts
@@ -1,18 +1,16 @@
 import { Sequelize } from "sequelize";
-import dotenv from "dotenv";
+import { DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER } from "../../config/secrets";
 
-dotenv.config();
-
-const sequelize = new Sequelize({ 
-    dialect: 'mysql',
-    host: process.env.DB_HOST,   
-    username: process.env.DB_USER,   
-    password: process.env.DB_PASS,   
-    database: process.env.DB_NAME,   
-    port: Number(process.env.DB_PORT),  
-    define: {     
-        timestamps: true,   
-    },
+const sequelize = new Sequelize({
+  dialect: 'mysql',
+  host: DB_HOST,
+  username: DB_USER,
+  password: DB_PASS,
+  database: DB_NAME,
+  port: Number(DB_PORT),
+  define: {
+    timestamps: true,
+  },
 })
 
 export default sequelize;


### PR DESCRIPTION
Instead of having process.env.KEY everywhere in project, it's better to have them in one place and export them from there.

Which also allows for checking if those keys exists or not. And we can stop server from starting if all the required keys are not present instead of app crashing in middle of an operation 